### PR TITLE
feat: move partial sync to app.tsx and use it to pass loading state to detail view

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -415,6 +415,7 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
 
   const partialSyncComplete = partialSync.endKey === undefined;
   useEffect(() => {
+    console.log("partialSync", partialSync.endKey);
     if (!partialSyncComplete) {
       rep.pull();
     }

--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -340,6 +340,7 @@ function reducer(
 
 interface LayoutProps {
   view: string | null;
+  isLoading: boolean;
   state: State;
   rep: Replicache<M>;
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
@@ -348,6 +349,7 @@ interface LayoutProps {
 
 const Layout = ({
   view,
+  isLoading,
   state,
   rep,
   onUpdateIssues,
@@ -368,7 +370,7 @@ const Layout = ({
           rep={rep}
           onUpdateIssues={onUpdateIssues}
           onAddComment={onCreateComment}
-          isLoading={false}
+          isLoading={isLoading}
         />
       );
     default:
@@ -502,6 +504,7 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
           )}
           <Layout
             view={view}
+            isLoading={!partialSyncComplete}
             state={state}
             rep={rep}
             onUpdateIssues={handleUpdateIssues}

--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -340,6 +340,7 @@ function reducer(
 
 interface LayoutProps {
   view: string | null;
+  detailIssueID: string | null;
   isLoading: boolean;
   state: State;
   rep: Replicache<M>;
@@ -347,41 +348,41 @@ interface LayoutProps {
   onCreateComment: (comment: Comment) => void;
 }
 
-const Layout = ({
+const MainContent = ({
   view,
+  detailIssueID,
   isLoading,
   state,
   rep,
   onUpdateIssues,
   onCreateComment,
 }: LayoutProps) => {
-  switch (view) {
-    case "board":
-      return (
-        <IssueBoard
-          issues={state.filteredIssues}
-          onUpdateIssues={onUpdateIssues}
-        />
-      );
-    case "detail":
-      return (
-        <IssueDetail
-          issues={state.filteredIssues}
-          rep={rep}
-          onUpdateIssues={onUpdateIssues}
-          onAddComment={onCreateComment}
-          isLoading={isLoading}
-        />
-      );
-    default:
-      return (
-        <IssueList
-          issues={state.filteredIssues}
-          onUpdateIssues={onUpdateIssues}
-          view={view}
-        />
-      );
+  if (detailIssueID) {
+    return (
+      <IssueDetail
+        issues={state.filteredIssues}
+        rep={rep}
+        onUpdateIssues={onUpdateIssues}
+        onAddComment={onCreateComment}
+        isLoading={isLoading}
+      />
+    );
   }
+  if (view === "board") {
+    return (
+      <IssueBoard
+        issues={state.filteredIssues}
+        onUpdateIssues={onUpdateIssues}
+      />
+    );
+  }
+  return (
+    <IssueList
+      issues={state.filteredIssues}
+      onUpdateIssues={onUpdateIssues}
+      view={view}
+    />
+  );
 };
 
 const App = ({ rep }: { rep: Replicache<M> }) => {
@@ -389,6 +390,7 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
   const [priorityFilter] = useQueryState("priorityFilter");
   const [statusFilter] = useQueryState("statusFilter");
   const [orderBy] = useQueryState("orderBy");
+  const [detailIssueID] = useQueryState("iss");
   const [menuVisible, setMenuVisible] = useState(false);
 
   const [state, dispatch] = useReducer(timedReducer, {
@@ -489,7 +491,7 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
           onCreateIssue={handleCreateIssue}
         />
         <div className="flex flex-col flex-grow min-w-0">
-          {view !== "detail" && (
+          {detailIssueID === null && (
             <TopFilter
               onToggleMenu={() => setMenuVisible(!menuVisible)}
               title={getTitle(view)}
@@ -502,8 +504,9 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
               showSortOrderMenu={view !== "board"}
             />
           )}
-          <Layout
+          <MainContent
             view={view}
+            detailIssueID={detailIssueID}
             isLoading={!partialSyncComplete}
             state={state}
             rep={rep}

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -60,7 +60,7 @@ const CommentsList = (comments: Comment[], isLoading: boolean) => {
   return elements;
 };
 
-const handleClickCloseBtn = async () => {
+const handleClose = async () => {
   history.back();
 };
 
@@ -226,7 +226,7 @@ export default function IssueDetail({
           <div className="flex flex-row flex-initial ml-3">
             <div
               className="inline-flex items-center justify-center h-6 w-6 rounded  hover:bg-gray-410  cursor-pointer"
-              onMouseDown={handleClickCloseBtn}
+              onMouseDown={handleClose}
             >
               <CloseIcon className="w-4" />
             </div>

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -35,8 +35,8 @@ interface Props {
   rep: Replicache<M>;
 }
 
-const commentsList = (comments: Comment[], isLoading: boolean) => {
-  return comments.map((comment) => (
+const CommentsList = (comments: Comment[], isLoading: boolean) => {
+  const elements = comments.map((comment) => (
     <div
       key={comment.id}
       className=" max-w-[85vw] mx-3 bg-gray-400 mt-0 mb-5 border-transparent rounded py-3 px-3 relative whitespace-pre-wrap overflow-auto"
@@ -46,10 +46,18 @@ const commentsList = (comments: Comment[], isLoading: boolean) => {
         {comment.creator} {timeAgo(comment.created)}
       </div>
       <div className="block flex-1 whitespace-pre-wrap">
-        {isLoading ? "Loading..." : <Remark>{comment.body}</Remark>}
+        <Remark>{comment.body}</Remark>
       </div>
     </div>
   ));
+  if (isLoading) {
+    elements.push(
+      <div className=" max-w-[85vw] mx-3 bg-gray-400 mt-0 mb-5 border-transparent rounded py-3 px-3 relative whitespace-pre-wrap overflow-auto">
+        Loading...
+      </div>
+    );
+  }
+  return elements;
 };
 
 const handleClickCloseBtn = async () => {
@@ -96,15 +104,15 @@ export default function IssueDetail({
     null,
     [iss]
   );
-  const description = useSubscribe<Description>(
+  const description = useSubscribe<Description | null>(
     rep,
     async (tx) => {
       if (iss) {
-        return (await getIssueDescription(tx, iss)) || "";
+        return (await getIssueDescription(tx, iss)) || null;
       }
-      return "";
+      return null;
     },
-    "",
+    null,
     [iss]
   );
 
@@ -311,17 +319,17 @@ export default function IssueDetail({
                   <textarea
                     className="block  px-2 py-1 whitespace-pre-wrap text-size-sm w-full bg-gray-400 h-[calc(100vh-340px)] placeholder-gray-100 placeholder:text-sm"
                     onChange={(e) => setDescription(e.target.value)}
-                    defaultValue={description}
+                    defaultValue={description || ""}
                   />
-                ) : isLoading ? (
+                ) : isLoading && description === null ? (
                   "Loading..."
                 ) : (
-                  <Remark>{description}</Remark>
+                  <Remark>{description || ""}</Remark>
                 )}
               </div>
             </div>
             <div className="text-md py-4 px-5 text-gray-4">Comments</div>
-            {commentsList(comments, isLoading)}
+            {CommentsList(comments, isLoading)}
             <div className="mx-3 bg-gray-400 flex-1 mx- mt-0 mb-3 flex-1 border-transparent rounded full py-3 px-3 relative whitespace-pre-wrap ">
               <textarea
                 className="block flex-1 whitespace-pre-wrap text-size-sm w-full bg-gray-400 min-h-[6rem] placeholder-gray-100 placeholder:text-sm"

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -17,7 +17,7 @@ import {
   IssueUpdate,
 } from "./issue";
 import StatusMenu from "./status-menu";
-import { queryTypes, useQueryStates } from "next-usequerystate";
+import { useQueryState } from "next-usequerystate";
 
 import type { Replicache } from "replicache";
 import type { M } from "./mutators";
@@ -71,9 +71,8 @@ export default function IssueDetail({
   issues,
   isLoading,
 }: Props) {
-  const [detailView, setDetailView] = useQueryStates({
-    view: queryTypes.string,
-    iss: queryTypes.string,
+  const [detailIssueID, setDetailIssueID] = useQueryState("iss", {
+    history: "push",
   });
 
   const [editMode, setEditMode] = useState(false);
@@ -84,48 +83,46 @@ export default function IssueDetail({
   const [titleText, setTitle] = useState("");
   const [descriptionText, setDescription] = useState("");
 
-  const { iss } = detailView;
-
   useEffect(() => {
-    if (detailView.iss) {
-      const index = issues.findIndex((issue) => issue.id === detailView.iss);
+    if (detailIssueID) {
+      const index = issues.findIndex((issue) => issue.id === detailIssueID);
       setCurrentIssueIdx(index);
     }
-  }, [issues, detailView.iss]);
+  }, [issues, detailIssueID]);
 
   const issue = useSubscribe<Issue | null>(
     rep,
     async (tx) => {
-      if (iss) {
-        return (await getIssue(tx, iss)) || null;
+      if (detailIssueID) {
+        return (await getIssue(tx, detailIssueID)) || null;
       }
       return null;
     },
     null,
-    [iss]
+    [detailIssueID]
   );
   const description = useSubscribe<Description | null>(
     rep,
     async (tx) => {
-      if (iss) {
-        return (await getIssueDescription(tx, iss)) || null;
+      if (detailIssueID) {
+        return (await getIssueDescription(tx, detailIssueID)) || null;
       }
       return null;
     },
     null,
-    [iss]
+    [detailIssueID]
   );
 
   const comments = useSubscribe<Comment[] | []>(
     rep,
     async (tx) => {
-      if (iss) {
-        return (await getIssueComments(tx, iss)) || [];
+      if (detailIssueID) {
+        return (await getIssueComments(tx, detailIssueID)) || [];
       }
       return [];
     },
     [],
-    [iss]
+    [detailIssueID]
   );
 
   const handleChangePriority = useCallback(
@@ -187,15 +184,12 @@ export default function IssueDetail({
         newIss = issues[currentIssueIdx + 1].id;
       }
 
-      await setDetailView(
-        { iss: newIss },
-        {
-          scroll: false,
-          shallow: true,
-        }
-      );
+      await setDetailIssueID(newIss, {
+        scroll: false,
+        shallow: true,
+      });
     },
-    [currentIssueIdx, issues, setDetailView]
+    [currentIssueIdx, issues, setDetailIssueID]
   );
 
   const handleFwd = useCallback(async () => {

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -60,10 +60,6 @@ const CommentsList = (comments: Comment[], isLoading: boolean) => {
   return elements;
 };
 
-const handleClose = async () => {
-  history.back();
-};
-
 export default function IssueDetail({
   rep,
   onUpdateIssues,
@@ -124,6 +120,10 @@ export default function IssueDetail({
     [],
     [detailIssueID]
   );
+
+  const handleClose = useCallback(async () => {
+    await setDetailIssueID(null);
+  }, [setDetailIssueID]);
 
   const handleChangePriority = useCallback(
     (priority: Priority) => {

--- a/frontend/issue-item.tsx
+++ b/frontend/issue-item.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
 import type { Issue, Priority } from "./issue";
-import { queryTypes, useQueryStates } from "next-usequerystate";
+import { useQueryState } from "next-usequerystate";
 import IssueItemBase from "./issue-item-base";
 
 interface IssueProps {
@@ -9,26 +9,19 @@ interface IssueProps {
 }
 
 const IssueItem = ({ issue, onChangePriority }: IssueProps) => {
-  const [, setDetailView] = useQueryStates(
-    {
-      view: queryTypes.string,
-      iss: queryTypes.string,
-    },
-    { history: "push" }
-  );
+  const [, setDetailIssueID] = useQueryState("iss", {
+    history: "push",
+  });
 
   const handleChangePriority = (p: Priority) => {
     if (onChangePriority) onChangePriority(issue, p);
   };
 
   const handleIssueItemClick = async () => {
-    await setDetailView(
-      { view: "detail", iss: issue.id },
-      {
-        scroll: false,
-        shallow: true,
-      }
-    );
+    await setDetailIssueID(issue.id, {
+      scroll: false,
+      shallow: true,
+    });
   };
 
   return (

--- a/frontend/issue-row.tsx
+++ b/frontend/issue-row.tsx
@@ -3,7 +3,7 @@ import type { Issue, Priority, Status } from "./issue";
 import { formatDate } from "../util/date";
 import PriorityMenu from "./priority-menu";
 import StatusMenu from "./status-menu";
-import { queryTypes, useQueryStates } from "next-usequerystate";
+import { useQueryState } from "next-usequerystate";
 
 interface Props {
   issue: Issue;
@@ -12,13 +12,9 @@ interface Props {
 }
 
 function IssueRow({ issue, onChangePriority, onChangeStatus }: Props) {
-  const [, setDetailView] = useQueryStates(
-    {
-      view: queryTypes.string,
-      iss: queryTypes.string,
-    },
-    { history: "push" }
-  );
+  const [, setDetailIssueID] = useQueryState("iss", {
+    history: "push",
+  });
   const handleChangePriority = (p: Priority) => {
     if (onChangePriority) onChangePriority(issue, p);
   };
@@ -28,13 +24,10 @@ function IssueRow({ issue, onChangePriority, onChangeStatus }: Props) {
   };
 
   const handleIssueRowClick = async () => {
-    await setDetailView(
-      { view: "detail", iss: issue.id },
-      {
-        scroll: false,
-        shallow: true,
-      }
-    );
+    await setDetailIssueID(issue.id, {
+      scroll: false,
+      shallow: true,
+    });
   };
 
   return (

--- a/frontend/left-menu.tsx
+++ b/frontend/left-menu.tsx
@@ -9,7 +9,7 @@ import SearchBox from "./searchbox";
 import IssueModal from "./issue-modal";
 import ReactLogo from "./assets/images/logo.svg";
 import type { Description, Issue } from "./issue";
-import { useQueryState } from "next-usequerystate";
+import { queryTypes, useQueryState, useQueryStates } from "next-usequerystate";
 import AboutModal from "./about-modal";
 
 interface Props {
@@ -23,7 +23,10 @@ interface Props {
 }
 
 const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
-  const [, setLayoutViewParam] = useQueryState("view", { history: "push" });
+  const [, setLayoutViewParams] = useQueryStates(
+    { view: queryTypes.string, iss: queryTypes.string },
+    { history: "push" }
+  );
 
   const [disableAbout] = useQueryState("disableAbout");
 
@@ -64,7 +67,7 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
             <div
               className="flex items-center p-2 pr-3 rounded cursor-pointer hover:bg-gray-400"
               onMouseDown={async () => {
-                await setLayoutViewParam(null);
+                await setLayoutViewParams({ view: null, iss: null });
                 onCloseMenu && onCloseMenu();
               }}
             >
@@ -96,7 +99,7 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
             <div
               className="flex items-center pl-9 rounded cursor-pointer group h-8 hover:bg-gray-450"
               onMouseDown={async () => {
-                await setLayoutViewParam("all");
+                await setLayoutViewParams({ view: "all", iss: null });
                 onCloseMenu && onCloseMenu();
               }}
             >
@@ -106,7 +109,7 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
             <div
               className="flex items-center pl-9 rounded cursor-pointer group h-8 hover:bg-gray-450"
               onMouseDown={async () => {
-                await setLayoutViewParam("active");
+                await setLayoutViewParams({ view: "active", iss: null });
                 onCloseMenu && onCloseMenu();
               }}
             >
@@ -116,7 +119,7 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
             <div
               className="flex items-center pl-9 rounded cursor-pointer group h-8 hover:bg-gray-450"
               onMouseDown={async () => {
-                await setLayoutViewParam("backlog");
+                await setLayoutViewParams({ view: "backlog", iss: null });
                 onCloseMenu && onCloseMenu();
               }}
             >
@@ -125,7 +128,7 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
             <div
               className="flex items-center pl-9 rounded cursor-pointer group h-8 hover:bg-gray-450"
               onMouseDown={async () => {
-                await setLayoutViewParam("board");
+                await setLayoutViewParams({ view: "board", iss: null });
                 onCloseMenu && onCloseMenu();
               }}
             >

--- a/frontend/left-menu.tsx
+++ b/frontend/left-menu.tsx
@@ -9,7 +9,6 @@ import SearchBox from "./searchbox";
 import IssueModal from "./issue-modal";
 import ReactLogo from "./assets/images/logo.svg";
 import type { Description, Issue } from "./issue";
-import { useRouter } from "next/router";
 import { useQueryState } from "next-usequerystate";
 import AboutModal from "./about-modal";
 
@@ -31,9 +30,6 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
   const ref = useRef<HTMLDivElement>() as RefObject<HTMLDivElement>;
   const [issueModalVisible, setIssueModalVisible] = useState(false);
   const [aboutModalVisible, setAboutModalVisible] = useState(true);
-
-  const router = useRouter();
-  const { id } = router.query;
 
   const classes = classnames(
     "absolute lg:static inset-0 lg:relative lg:translate-x-0 flex flex-col flex-shrink-0 w-56 font-sans text-sm border-r lg:shadow-none justify-items-start bg-gray-500 border-gray-400 text-white bg-opacity-1",

--- a/frontend/left-menu.tsx
+++ b/frontend/left-menu.tsx
@@ -66,14 +66,18 @@ const LeftMenu = ({ menuVisible, onCloseMenu, onCreateIssue }: Props) => {
         <div className="flex flex-col flex-grow-0 flex-shrink-0 px-5 py-3">
           <div className="flex items-center justify-between">
             {/* Project selection */}
-            <Link href={`/d/${id}`}>
-              <div className="flex items-center p-2 pr-3 rounded cursor-pointer hover:bg-gray-400">
-                <div className="w-8 text-white">
-                  <ReactLogo />
-                </div>
-                <div className="text-sm font-medium">React</div>
+            <div
+              className="flex items-center p-2 pr-3 rounded cursor-pointer hover:bg-gray-400"
+              onMouseDown={async () => {
+                await setLayoutViewParam(null);
+                onCloseMenu && onCloseMenu();
+              }}
+            >
+              <div className="w-8 text-white">
+                <ReactLogo />
               </div>
-            </Link>
+              <div className="text-sm font-medium">React</div>
+            </div>
           </div>
 
           {/* Create issue btn */}

--- a/frontend/left-menu.tsx
+++ b/frontend/left-menu.tsx
@@ -2,7 +2,6 @@ import React, { RefObject, useRef, useState } from "react";
 import AddIcon from "./assets/icons/add.svg";
 import HelpIcon from "./assets/icons/help.svg";
 import MenuIcon from "./assets/icons/menu.svg";
-import Link from "next/link";
 import ItemGroup from "./item-group";
 import { useClickOutside } from "./hooks/useClickOutside";
 import classnames from "classnames";

--- a/pages/d/[id].tsx
+++ b/pages/d/[id].tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ReadonlyJSONValue, Replicache } from "replicache";
+import { Replicache } from "replicache";
 import { M, mutators } from "../../frontend/mutators";
 import App from "../../frontend/app";
 import { createClient } from "@supabase/supabase-js";
@@ -27,24 +27,6 @@ export default function Home() {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         licenseKey: process.env.NEXT_PUBLIC_REPLICACHE_LICENSE_KEY!,
       });
-      const unsub = r.subscribe(
-        (tx) => {
-          return tx.get("control/partialSync");
-        },
-        {
-          onData: (result: ReadonlyJSONValue | undefined) => {
-            console.log("partialSync", result);
-            if (
-              (result === undefined ||
-                (result as { endKey?: string }).endKey) !== undefined
-            ) {
-              r.pull();
-            } else {
-              unsub();
-            }
-          },
-        }
-      );
 
       const supabase = createClient(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
This enables us to show a loading messages for descriptions and comments until partial sync is complete.

Also removes the view=detail.  Changing the view param to go in to detail changed the filtered issue list
resulting in incorrect next/prev detail navigation.  Instead we leave view unchanged, and trigger detail view
whenever there is a `iss` (i.e. detail issue id) param. 