### PR TITLE
perf: optimize scrolling and navigation perf

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -34,7 +34,6 @@ import IssueDetail from "./issue-detail";
 import { generateKeyBetween } from "fractional-indexing";
 import { useSubscribe } from "replicache-react";
 import classnames from "classnames";
-import classNames from "classnames";
 
 class Filters {
   private readonly _viewStatuses: Set<Status> | undefined;
@@ -511,7 +510,7 @@ const RawLayout = ({
         />
         <div className="flex flex-col flex-grow min-w-0">
           <div
-            className={classNames("flex flex-col", {
+            className={classnames("flex flex-col", {
               hidden: detailIssueID,
             })}
           >

--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -443,6 +443,13 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
     },
     [setDetailIssueID]
   );
+  const handleCloseMenu = useCallback(() => setMenuVisible(false), [
+    setMenuVisible,
+  ]);
+  const handleToggleMenu = useCallback(() => setMenuVisible(!menuVisible), [
+    setMenuVisible,
+    menuVisible,
+  ]);
 
   return (
     <Layout
@@ -452,7 +459,8 @@ const App = ({ rep }: { rep: Replicache<M> }) => {
       isLoading={!partialSyncComplete}
       state={state}
       rep={rep}
-      setMenuVisible={setMenuVisible}
+      onCloseMenu={handleCloseMenu}
+      onToggleMenu={handleToggleMenu}
       onUpdateIssues={handleUpdateIssues}
       onCreateIssue={handleCreateIssue}
       onCreateComment={handleCreateComment}
@@ -468,7 +476,8 @@ interface LayoutProps {
   isLoading: boolean;
   state: State;
   rep: Replicache<M>;
-  setMenuVisible: (visible: boolean) => void;
+  onCloseMenu: () => void;
+  onToggleMenu: () => void;
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onCreateIssue: (
     issue: Omit<Issue, "kanbanOrder">,
@@ -485,26 +494,19 @@ const RawLayout = ({
   isLoading,
   state,
   rep,
-  setMenuVisible,
+  onCloseMenu,
+  onToggleMenu,
   onUpdateIssues,
   onCreateIssue,
   onCreateComment,
   onOpenDetail,
 }: LayoutProps) => {
-  const handleCloseMenu = useCallback(() => setMenuVisible(false), [
-    setMenuVisible,
-  ]);
-  const handleToggleMenu = useCallback(() => setMenuVisible(!menuVisible), [
-    setMenuVisible,
-    menuVisible,
-  ]);
-
   return (
     <div>
       <div className="flex w-full h-screen overflow-y-hidden">
         <LeftMenu
           menuVisible={menuVisible}
-          onCloseMenu={handleCloseMenu}
+          onCloseMenu={onCloseMenu}
           onCreateIssue={onCreateIssue}
         />
         <div className="flex flex-col flex-grow min-w-0">
@@ -514,7 +516,7 @@ const RawLayout = ({
             })}
           >
             <TopFilter
-              onToggleMenu={handleToggleMenu}
+              onToggleMenu={onToggleMenu}
               title={getTitle(view)}
               filteredIssuesCount={
                 state.filters.hasNonViewFilters

--- a/frontend/issue-board.tsx
+++ b/frontend/issue-board.tsx
@@ -1,6 +1,6 @@
 import { generateNKeysBetween } from "fractional-indexing";
 import { groupBy, indexOf } from "lodash";
-import React, { useCallback } from "react";
+import React, { memo, useCallback } from "react";
 import { DragDropContext, DropResult } from "react-beautiful-dnd";
 
 import { Status, Issue, IssueUpdate, Priority } from "./issue";
@@ -73,9 +73,10 @@ export function getKanbanOrderIssueUpdates(
 interface Props {
   issues: Issue[];
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
+  onOpenDetail: (issue: Issue) => void;
 }
 
-export default function IssueBoard({ issues, onUpdateIssues }: Props) {
+function IssueBoard({ issues, onUpdateIssues, onOpenDetail }: Props) {
   const issuesByType = getIssueByType(issues);
 
   const handleDragEnd = useCallback(
@@ -123,32 +124,39 @@ export default function IssueBoard({ issues, onUpdateIssues }: Props) {
           status={Status.BACKLOG}
           issues={issuesByType[Status.BACKLOG]}
           onChangePriority={handleChangePriority}
+          onOpenDetail={onOpenDetail}
         />
         <IssueCol
           title={"Todo"}
           status={Status.TODO}
           issues={issuesByType[Status.TODO]}
           onChangePriority={handleChangePriority}
+          onOpenDetail={onOpenDetail}
         />
         <IssueCol
           title={"In Progress"}
           status={Status.IN_PROGRESS}
           issues={issuesByType[Status.IN_PROGRESS]}
           onChangePriority={handleChangePriority}
+          onOpenDetail={onOpenDetail}
         />
         <IssueCol
           title={"Done"}
           status={Status.DONE}
           issues={issuesByType[Status.DONE]}
           onChangePriority={handleChangePriority}
+          onOpenDetail={onOpenDetail}
         />
         <IssueCol
           title={"Canceled"}
           status={Status.CANCELED}
           issues={issuesByType[Status.CANCELED]}
           onChangePriority={handleChangePriority}
+          onOpenDetail={onOpenDetail}
         />
       </div>
     </DragDropContext>
   );
 }
+
+export default memo(IssueBoard);

--- a/frontend/issue-col.tsx
+++ b/frontend/issue-col.tsx
@@ -11,13 +11,13 @@ import type { Issue, Priority, Status } from "./issue";
 import IssueItem from "./issue-item";
 import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
-import IssueItemBase from "./issue-item-base";
 
 interface Props {
   status: Status;
   title: string;
   issues: Array<Issue>;
   onChangePriority: (issue: Issue, priority: Priority) => void;
+  onOpenDetail: (issue: Issue) => void;
 }
 
 interface RowProps {
@@ -25,6 +25,7 @@ interface RowProps {
   data: {
     issues: Array<Issue>;
     onChangePriority: (issue: Issue, priority: Priority) => void;
+    onOpenDetail: (issue: Issue) => void;
   };
   style: CSSProperties;
 }
@@ -54,6 +55,7 @@ const RowPreMemo = ({ data, index, style }: RowProps) => {
               issue={issue}
               key={index}
               onChangePriority={data.onChangePriority}
+              onOpenDetail={data.onOpenDetail}
             />
           </div>
         );
@@ -63,13 +65,20 @@ const RowPreMemo = ({ data, index, style }: RowProps) => {
 };
 const Row = memo(RowPreMemo);
 
-function IssueCol({ title, status, issues, onChangePriority }: Props) {
+function IssueCol({
+  title,
+  status,
+  issues,
+  onChangePriority,
+  onOpenDetail,
+}: Props) {
   const itemData = useMemo(
     () => ({
       issues,
       onChangePriority,
+      onOpenDetail,
     }),
-    [issues, onChangePriority]
+    [issues, onChangePriority, onOpenDetail]
   );
   const statusIcon = <StatusIcon className="flex-shrink-0" status={status} />;
   return (
@@ -98,7 +107,7 @@ function IssueCol({ title, status, issues, onChangePriority }: Props) {
                 {...provided.draggableProps}
                 {...provided.dragHandleProps}
               >
-                <IssueItemBase issue={issue} />
+                <IssueItem issue={issue} />
               </div>
             );
           }}

--- a/frontend/issue-item.tsx
+++ b/frontend/issue-item.tsx
@@ -1,35 +1,47 @@
-import React, { memo } from "react";
+import React, { memo, useCallback } from "react";
 import type { Issue, Priority } from "./issue";
-import { useQueryState } from "next-usequerystate";
-import IssueItemBase from "./issue-item-base";
+import classnames from "classnames";
+import PriorityMenu from "./priority-menu";
 
-interface IssueProps {
+interface Props {
   issue: Issue;
-  onChangePriority: (issue: Issue, priority: Priority) => void;
+  onChangePriority?: (issue: Issue, priority: Priority) => void;
+  onOpenDetail?: (issue: Issue) => void;
 }
 
-const IssueItem = ({ issue, onChangePriority }: IssueProps) => {
-  const [, setDetailIssueID] = useQueryState("iss", {
-    history: "push",
-  });
+const IssueItem = ({ issue, onChangePriority, onOpenDetail }: Props) => {
+  const handleChangePriority = useCallback(
+    (p: Priority) => {
+      onChangePriority && onChangePriority(issue, p);
+    },
+    [issue, onChangePriority]
+  );
 
-  const handleChangePriority = (p: Priority) => {
-    if (onChangePriority) onChangePriority(issue, p);
-  };
-
-  const handleIssueItemClick = async () => {
-    await setDetailIssueID(issue.id, {
-      scroll: false,
-      shallow: true,
-    });
-  };
+  const handleIssueItemClick = () => onOpenDetail && onOpenDetail(issue);
 
   return (
-    <IssueItemBase
-      issue={issue}
-      handleIssueItemClick={handleIssueItemClick}
-      handleChangePriority={handleChangePriority}
-    />
+    <div
+      className={classnames(
+        "bg-gray-850 cursor-pointer flex flex-col px-4 py-2 text-white rounded focus:outline-none"
+      )}
+      onClick={handleIssueItemClick}
+    >
+      <div className="flex justify-between w-full overflow-hidden">
+        <div className="flex flex-col">
+          <span className="text-xs font-normal uppercase"></span>
+          <span className="mt-1 text-sm font-medium text-gray-50 line-clamp-2 overflow-ellipsis h-10">
+            {issue.title}
+          </span>
+        </div>
+      </div>
+      <div className="mt-1 flex items-center">
+        <PriorityMenu
+          onSelect={handleChangePriority}
+          labelVisible={false}
+          priority={issue.priority}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/issue-list.tsx
+++ b/frontend/issue-list.tsx
@@ -1,4 +1,11 @@
-import React, { CSSProperties, useCallback, useEffect, useRef } from "react";
+import React, {
+  CSSProperties,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import IssueRow from "./issue-row";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
@@ -6,6 +13,7 @@ import type { Issue, IssueUpdate, Priority, Status } from "./issue";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
+  onOpenDetail: (issue: Issue) => void;
   issues: Issue[];
   view: string | null;
 }
@@ -14,11 +22,12 @@ type ListData = {
   issues: Issue[];
   handleChangePriority: (issue: Issue, priority: Priority) => void;
   handleChangeStatus: (issue: Issue, status: Status) => void;
+  onOpenDetail: (issue: Issue) => void;
 };
 
 const itemKey = (index: number, data: ListData) => data.issues[index].id;
 
-const Row = ({
+const RawRow = ({
   data,
   index,
   style,
@@ -32,11 +41,14 @@ const Row = ({
       issue={data.issues[index]}
       onChangePriority={data.handleChangePriority}
       onChangeStatus={data.handleChangeStatus}
+      onOpenDetail={data.onOpenDetail}
     />
   </div>
 );
 
-const IssueList = ({ onUpdateIssues, issues, view }: Props) => {
+const Row = memo(RawRow);
+
+const IssueList = ({ onUpdateIssues, onOpenDetail, issues, view }: Props) => {
   const fixedSizeListRef = useRef<FixedSizeList>(null);
   useEffect(() => {
     fixedSizeListRef.current?.scrollTo(0);
@@ -56,6 +68,11 @@ const IssueList = ({ onUpdateIssues, issues, view }: Props) => {
     [onUpdateIssues]
   );
 
+  const itemData = useMemo(
+    () => ({ issues, handleChangePriority, handleChangeStatus, onOpenDetail }),
+    [issues, handleChangePriority, handleChangeStatus, onOpenDetail]
+  );
+
   return (
     <div className="flex flex-col flex-grow overflow-auto">
       <AutoSizer>
@@ -65,11 +82,7 @@ const IssueList = ({ onUpdateIssues, issues, view }: Props) => {
             height={height}
             itemCount={issues.length}
             itemSize={43}
-            itemData={{
-              handleChangePriority,
-              handleChangeStatus,
-              issues,
-            }}
+            itemData={itemData}
             itemKey={itemKey}
             overscanCount={10}
             width={width}
@@ -82,4 +95,4 @@ const IssueList = ({ onUpdateIssues, issues, view }: Props) => {
   );
 };
 
-export default IssueList;
+export default memo(IssueList);

--- a/frontend/issue-row.tsx
+++ b/frontend/issue-row.tsx
@@ -3,32 +3,23 @@ import type { Issue, Priority, Status } from "./issue";
 import { formatDate } from "../util/date";
 import PriorityMenu from "./priority-menu";
 import StatusMenu from "./status-menu";
-import { useQueryState } from "next-usequerystate";
 
 interface Props {
   issue: Issue;
-  onChangePriority?: (issue: Issue, priority: Priority) => void;
-  onChangeStatus?: (issue: Issue, status: Status) => void;
+  onChangePriority: (issue: Issue, priority: Priority) => void;
+  onChangeStatus: (issue: Issue, status: Status) => void;
+  onOpenDetail: (issue: Issue) => void;
 }
 
-function IssueRow({ issue, onChangePriority, onChangeStatus }: Props) {
-  const [, setDetailIssueID] = useQueryState("iss", {
-    history: "push",
-  });
-  const handleChangePriority = (p: Priority) => {
-    if (onChangePriority) onChangePriority(issue, p);
-  };
-
-  const handleChangeStatus = (status: Status) => {
-    if (onChangeStatus) onChangeStatus(issue, status);
-  };
-
-  const handleIssueRowClick = async () => {
-    await setDetailIssueID(issue.id, {
-      scroll: false,
-      shallow: true,
-    });
-  };
+function IssueRow({
+  issue,
+  onChangePriority,
+  onChangeStatus,
+  onOpenDetail,
+}: Props) {
+  const handleChangePriority = (p: Priority) => onChangePriority(issue, p);
+  const handleChangeStatus = (status: Status) => onChangeStatus(issue, status);
+  const handleIssueRowClick = () => onOpenDetail(issue);
 
   return (
     <div

--- a/frontend/priority-menu.tsx
+++ b/frontend/priority-menu.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, RefObject, useRef, useState } from "react";
+import React, { memo, MouseEvent, RefObject, useRef, useState } from "react";
 import { usePopper } from "react-popper";
 import PriorityIcon from "./priority-icon";
 import HighPriorityIcon from "./assets/icons/signal-strong.svg";
@@ -28,19 +28,11 @@ const PriorityMenu = ({
   onSelect,
   priority = Priority.NONE,
 }: Props) => {
-  const [priorityRef, setPriorityRef] = useState<HTMLButtonElement | null>(
-    null
-  );
-  const [popperRef, setPopperRef] = useState<HTMLDivElement | null>(null);
+  const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
   const [priorityDropDownVisible, setPriorityDropDownVisible] = useState(false);
   const ref = useRef<HTMLDivElement>() as RefObject<HTMLDivElement>;
 
-  const { styles, attributes, update } = usePopper(priorityRef, popperRef, {
-    placement: "bottom-start",
-  });
-
   const handleDropdownClick = (e: MouseEvent) => {
-    update && update();
     e.stopPropagation();
     setPriorityDropDownVisible(!priorityDropDownVisible);
   };
@@ -89,7 +81,7 @@ const PriorityMenu = ({
     <div ref={ref}>
       <button
         className="inline-flex items-center h-6 px-2 border-none rounded focus:outline-none hover:bg-gray-850"
-        ref={setPriorityRef}
+        ref={setButtonRef}
         onClick={handleDropdownClick}
       >
         <PriorityIcon priority={priority} />
@@ -99,19 +91,38 @@ const PriorityMenu = ({
           </div>
         )}
       </button>
-      <div
-        ref={setPopperRef}
-        style={{
-          ...styles.popper,
-          display: priorityDropDownVisible ? "" : "none",
-        }}
-        {...attributes.popper}
-        className="cursor-default bg-white rounded shadow-modal z-100 w-34"
-      >
-        <div style={styles.offset}>{options}</div>
-      </div>
+      {priorityDropDownVisible && (
+        <Popper buttonRef={buttonRef}>{options}</Popper>
+      )}
     </div>
   );
 };
 
-export default PriorityMenu;
+const Popper = ({
+  buttonRef,
+  children,
+}: {
+  buttonRef: HTMLButtonElement | null;
+  children: React.ReactNode;
+}) => {
+  const [popperRef, setPopperRef] = useState<HTMLDivElement | null>(null);
+
+  const { styles, attributes } = usePopper(buttonRef, popperRef, {
+    placement: "bottom-start",
+  });
+
+  return (
+    <div
+      ref={setPopperRef}
+      style={{
+        ...styles.popper,
+      }}
+      {...attributes.popper}
+      className="cursor-default bg-white rounded shadow-modal z-100 w-34"
+    >
+      <div style={styles.offset}>{children}</div>
+    </div>
+  );
+};
+
+export default memo(PriorityMenu);

--- a/frontend/status-menu.tsx
+++ b/frontend/status-menu.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, RefObject, useRef, useState } from "react";
+import React, { memo, MouseEvent, RefObject, useRef, useState } from "react";
 import { usePopper } from "react-popper";
 import StatusIcon from "./status-icon";
 import CancelIcon from "./assets/icons/cancel.svg";
@@ -41,18 +41,12 @@ const getStatusString = (status: StatusEnum) => {
 };
 
 const StatusMenu = ({ labelVisible = false, onSelect, status }: Props) => {
-  const [statusRef, setStatusRef] = useState<HTMLButtonElement | null>(null);
-  const [popperRef, setPopperRef] = useState<HTMLDivElement | null>(null);
+  const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
   const [statusDropDownVisible, setStatusDropDownVisible] = useState(false);
-
-  const { styles, attributes, update } = usePopper(statusRef, popperRef, {
-    placement: "bottom-start",
-  });
 
   const ref = useRef<HTMLDivElement>() as RefObject<HTMLDivElement>;
 
   const handleDropdownClick = (e: MouseEvent) => {
-    update && update();
     e.stopPropagation();
     setStatusDropDownVisible(!statusDropDownVisible);
   };
@@ -84,7 +78,7 @@ const StatusMenu = ({ labelVisible = false, onSelect, status }: Props) => {
     <div ref={ref}>
       <button
         className="inline-flex items-center h-6 px-2 border-none rounded focus:outline-none hover:bg-gray-850"
-        ref={setStatusRef}
+        ref={setButtonRef}
         onClick={handleDropdownClick}
       >
         <StatusIcon status={status} />
@@ -94,19 +88,38 @@ const StatusMenu = ({ labelVisible = false, onSelect, status }: Props) => {
           </div>
         )}
       </button>
-      <div
-        ref={setPopperRef}
-        style={{
-          ...styles.popper,
-          display: statusDropDownVisible ? "" : "none",
-        }}
-        {...attributes.popper}
-        className="cursor-default bg-white rounded shadow-modal z-100 w-34"
-      >
-        <div style={styles.offset}>{options}</div>
-      </div>
+      {statusDropDownVisible && (
+        <Popper buttonRef={buttonRef}>{options}</Popper>
+      )}
     </div>
   );
 };
 
-export default StatusMenu;
+const Popper = ({
+  buttonRef,
+  children,
+}: {
+  buttonRef: HTMLButtonElement | null;
+  children: React.ReactNode;
+}) => {
+  const [popperRef, setPopperRef] = useState<HTMLDivElement | null>(null);
+
+  const { styles, attributes } = usePopper(buttonRef, popperRef, {
+    placement: "bottom-start",
+  });
+
+  return (
+    <div
+      ref={setPopperRef}
+      style={{
+        ...styles.popper,
+      }}
+      {...attributes.popper}
+      className="cursor-default bg-white rounded shadow-modal z-100 w-34"
+    >
+      <div style={styles.offset}>{children}</div>
+    </div>
+  );
+};
+
+export default memo(StatusMenu);

--- a/frontend/top-filter.tsx
+++ b/frontend/top-filter.tsx
@@ -1,5 +1,5 @@
 import MenuIcon from "./assets/icons/menu.svg";
-import React from "react";
+import React, { memo } from "react";
 
 import SortOrderMenu from "./sort-order-menu";
 import { queryTypes, useQueryState } from "next-usequerystate";
@@ -82,7 +82,7 @@ const TopFilter = ({
 
   return (
     <>
-      <div className="flex justify-between flex-shrink-0 pl-2 lg:pl-9 pr-2 lg:pr-6 border-b border-gray-850 h-14  border-b-color-gray-50">
+      <div className="flex justify-between flex-shrink-0 pl-2 lg:pl-9 pr-2 lg:pr-6 border-b border-gray-850 h-14 border-b-color-gray-50">
         {/* left section */}
         <div className="flex items-center">
           <button
@@ -154,4 +154,4 @@ const TopFilter = ({
   );
 };
 
-export default TopFilter;
+export default memo(TopFilter);


### PR DESCRIPTION
Optimize scrolling and navigation perf
1. optimize back from detail navigation by continuing to render the IssueList/IssueBoard, just hidden.  This also helps to maintain scoll position in the list on back
2. optimize scrolling and nav rendering by updating StatusMenu and PriorityMenu (which are on every IssueRow) to only render a component contain usePopper when the menu is open.  usePopper uses context and was causing unnecessary re-renders of  StatusMenu and PriorityMenu.
3. remove useQueryState for detailIssueID from IssueItem and IssueRow.  useQueryState uses context, and so all of the IssueItems/IssueRows rerendered when 'iss' query param changed, even though IssueItem and IssueRow only used the setDetailIssueID api.  Instead thread down a onOpenDetail callback.
4. judiciously add React.memo at various layers.

Fixed #53