### PR TITLE
fix: fix overflow of content and ratio of columns when content is wide

### DIFF
--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -217,12 +217,12 @@ export default function IssueDetail({
   };
 
   return (
-    <div className="flex flex-col flex-grow m-3 rounded-md shadow-mdw-7xl	border-gray-850 border min-h-0 min-w-0">
+    <div className="flex flex-col flex-grow m-3 rounded-md shadow-mdw-7xl border-gray-850 border min-h-0 min-w-0">
       <div className="flex bg-gray-850 border border-gray-700 justify-around">
         <div className="flex-1 p-2">
           <div className="flex flex-row flex-initial ml-3">
             <div
-              className="inline-flex items-center justify-center h-6 w-6 rounded  hover:bg-gray-400  cursor-pointer"
+              className="inline-flex items-center justify-center h-6 w-6 rounded hover:bg-gray-400  cursor-pointer"
               onMouseDown={handleClose}
             >
               <CloseIcon className="w-4" />


### PR DESCRIPTION
1. The left column of detail will now gain a horizontal scroll bar rather than making the screen wider.
2. The left column/right column ratio is now fixed at 75%/25% independent of content (before wide labels like "In Progress" could make the right column larger than 25%).