### PR TITLE
refactor: Refactor cookie and partial sync state to improve comprehensibility

### DIFF
--- a/frontend/control.ts
+++ b/frontend/control.ts
@@ -1,0 +1,22 @@
+import type { ReadTransaction } from "replicache";
+import { z } from "zod";
+
+export const PARTIAL_SYNC_STATE_KEY = "control/partialSync";
+
+export const partialSyncStateSchema = z.union([
+  z.literal("ISSUES_SYNCED"),
+  z.object({ endKey: z.string() }),
+  z.literal("PARTIAL_SYNC_COMPLETE"),
+]);
+
+export type PartialSyncState = z.TypeOf<typeof partialSyncStateSchema>;
+
+export async function getPartialSyncState(
+  tx: ReadTransaction
+): Promise<PartialSyncState | undefined> {
+  const val = await tx.get(PARTIAL_SYNC_STATE_KEY);
+  if (val === undefined) {
+    return undefined;
+  }
+  return partialSyncStateSchema.parse(val);
+}


### PR DESCRIPTION
1. Define the schema of partial sync state explicitly (using zod)
2. Use the same partial sync state schema in the cookie and in the 'control/partialSync' entry.
3. Use explicit sentinel values "ISSUES_SYNCED", and "PARTIAL_SYNC_COMPLETE" rather than "", and undefined.