### PR TITLE
Jotai Spike

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -1,129 +1,37 @@
-import React, { memo, useCallback, useEffect, useReducer } from "react";
-import type {
-  ExperimentalDiff as Diff,
-  ReadonlyJSONValue,
-  ReadTransaction,
-  Replicache,
-} from "replicache";
-import LeftMenu from "./left-menu";
-import type { M } from "./mutators";
+import type { UndoManager } from "@rocicorp/undo";
+import classnames from "classnames";
+import { generateKeyBetween } from "fractional-indexing";
+import { useAtomValue, useSetAtom } from "jotai";
+import { minBy, pickBy } from "lodash";
+import { useQueryState } from "next-usequerystate";
+import { memo, useCallback, useEffect, useState } from "react";
+import { HotKeys } from "react-hotkeys";
+import type { ReadTransaction, Replicache } from "replicache";
+import { useSubscribe } from "replicache-react";
+import { getPartialSyncState, PartialSyncState } from "./control";
 import {
+  Comment,
+  Description,
   Issue,
-  issueFromKeyAndValue,
+  IssueUpdate,
+  IssueUpdateWithID,
   ISSUE_KEY_PREFIX,
   Order,
   orderEnumSchema,
-  Priority,
-  priorityEnumSchema,
-  Status,
-  statusEnumSchema,
-  Description,
-  Comment,
-  IssueUpdate,
-  reverseTimestampSortKey,
-  statusOrderValues,
-  priorityOrderValues,
-  IssueUpdateWithID,
 } from "./issue";
-import { useState } from "react";
-import TopFilter from "./top-filter";
-import IssueList from "./issue-list";
-import { useQueryState } from "next-usequerystate";
 import IssueBoard from "./issue-board";
-import { isEqual, minBy, partial, pickBy, sortBy, sortedIndexBy } from "lodash";
 import IssueDetail from "./issue-detail";
-import { generateKeyBetween } from "fractional-indexing";
-import { useSubscribe } from "replicache-react";
-import classnames from "classnames";
-import { getPartialSyncState, PartialSyncState } from "./control";
-import type { UndoManager } from "@rocicorp/undo";
-import { HotKeys } from "react-hotkeys";
-
-class Filters {
-  private readonly _viewStatuses: Set<Status> | undefined;
-  private readonly _issuesStatuses: Set<Status> | undefined;
-  private readonly _issuesPriorities: Set<Priority> | undefined;
-  readonly hasNonViewFilters: boolean;
-  constructor(
-    view: string | null,
-    priorityFilter: string | null,
-    statusFilter: string | null
-  ) {
-    this._viewStatuses = undefined;
-    switch (view?.toLowerCase()) {
-      case "active":
-        this._viewStatuses = new Set([Status.IN_PROGRESS, Status.TODO]);
-        break;
-      case "backlog":
-        this._viewStatuses = new Set([Status.BACKLOG]);
-        break;
-      default:
-        this._viewStatuses = undefined;
-    }
-
-    this._issuesStatuses = undefined;
-    this._issuesPriorities = undefined;
-    this.hasNonViewFilters = false;
-    if (statusFilter) {
-      this._issuesStatuses = new Set<Status>();
-      for (const s of statusFilter.split(",")) {
-        const parseResult = statusEnumSchema.safeParse(s);
-        if (
-          parseResult.success &&
-          (!this._viewStatuses || this._viewStatuses.has(parseResult.data))
-        ) {
-          this.hasNonViewFilters = true;
-          this._issuesStatuses.add(parseResult.data);
-        }
-      }
-    }
-    if (!this.hasNonViewFilters) {
-      this._issuesStatuses = this._viewStatuses;
-    }
-
-    if (priorityFilter) {
-      this._issuesPriorities = new Set<Priority>();
-      for (const p of priorityFilter.split(",")) {
-        const parseResult = priorityEnumSchema.safeParse(p);
-        if (parseResult.success) {
-          this.hasNonViewFilters = true;
-          this._issuesPriorities.add(parseResult.data);
-        }
-      }
-      if (this._issuesPriorities.size === 0) {
-        this._issuesPriorities = undefined;
-      }
-    }
-  }
-
-  viewFilter(issue: Issue): boolean {
-    return this._viewStatuses ? this._viewStatuses.has(issue.status) : true;
-  }
-
-  issuesFilter(issue: Issue): boolean {
-    if (this._issuesStatuses) {
-      if (!this._issuesStatuses.has(issue.status)) {
-        return false;
-      }
-    }
-    if (this._issuesPriorities) {
-      if (!this._issuesPriorities.has(issue.priority)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  equals(other: Filters): boolean {
-    return (
-      this === other ||
-      (isEqual(this._viewStatuses, other._viewStatuses) &&
-        isEqual(this._issuesStatuses, other._issuesStatuses) &&
-        isEqual(this._issuesPriorities, other._issuesPriorities) &&
-        isEqual(this.hasNonViewFilters, other.hasNonViewFilters))
-    );
-  }
-}
+import IssueList from "./issue-list";
+import LeftMenu from "./left-menu";
+import type { M } from "./mutators";
+import {
+  allIssuesMapAtom,
+  diffHandlerAtom,
+  Filters,
+  filtersAtom,
+  issueOrderAtom,
+} from "./state";
+import TopFilter from "./top-filter";
 
 function getFilters(
   view: string | null,
@@ -141,202 +49,6 @@ function getIssueOrder(view: string | null, orderBy: string | null): Order {
   return parseResult.success ? parseResult.data : Order.MODIFIED;
 }
 
-function getTitle(view: string | null) {
-  switch (view?.toLowerCase()) {
-    case "active":
-      return "Active issues";
-    case "backlog":
-      return "Backlog issues";
-    case "board":
-      return "Board";
-    default:
-      return "All issues";
-  }
-}
-
-type State = {
-  allIssuesMap: Map<string, Issue>;
-  viewIssueCount: number;
-  filteredIssues: Issue[];
-  filters: Filters;
-  issueOrder: Order;
-};
-function timedReducer(
-  state: State,
-  action:
-    | {
-        type: "diff";
-        diff: Diff;
-      }
-    | {
-        type: "setFilters";
-        filters: Filters;
-      }
-    | {
-        type: "setIssueOrder";
-        issueOrder: Order;
-      }
-): State {
-  const start = Date.now();
-  const result = reducer(state, action);
-  console.log(`Reducer took ${Date.now() - start}ms`, action);
-  return result;
-}
-
-function getOrderValue(issueOrder: Order, issue: Issue): string {
-  let orderValue: string;
-  switch (issueOrder) {
-    case Order.CREATED:
-      orderValue = reverseTimestampSortKey(issue.created, issue.id);
-      break;
-    case Order.MODIFIED:
-      orderValue = reverseTimestampSortKey(issue.modified, issue.id);
-      break;
-    case Order.STATUS:
-      orderValue =
-        statusOrderValues[issue.status] +
-        "-" +
-        reverseTimestampSortKey(issue.modified, issue.id);
-      break;
-    case Order.PRIORITY:
-      orderValue =
-        priorityOrderValues[issue.priority] +
-        "-" +
-        reverseTimestampSortKey(issue.modified, issue.id);
-      break;
-    case Order.KANBAN:
-      orderValue = issue.kanbanOrder + "-" + issue.id;
-      break;
-  }
-  return orderValue;
-}
-
-function reducer(
-  state: State,
-  action:
-    | {
-        type: "diff";
-        diff: Diff;
-      }
-    | {
-        type: "setFilters";
-        filters: Filters;
-      }
-    | {
-        type: "setIssueOrder";
-        issueOrder: Order;
-      }
-): State {
-  const filters = action.type === "setFilters" ? action.filters : state.filters;
-  const issueOrder =
-    action.type === "setIssueOrder" ? action.issueOrder : state.issueOrder;
-  const orderIteratee = partial(getOrderValue, issueOrder);
-  function filterAndSort(issues: Issue[]): Issue[] {
-    return sortBy(
-      issues.filter((issue) => filters.issuesFilter(issue)),
-      orderIteratee
-    );
-  }
-  function countViewIssues(issues: Issue[]): number {
-    let count = 0;
-    for (const issue of issues) {
-      if (filters.viewFilter(issue)) {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  switch (action.type) {
-    case "diff": {
-      return diffReducer(state, action.diff);
-    }
-    case "setFilters": {
-      if (action.filters.equals(state.filters)) {
-        return state;
-      }
-      const allIssues = [...state.allIssuesMap.values()];
-      return {
-        ...state,
-        viewIssueCount: countViewIssues(allIssues),
-        filters: action.filters,
-        filteredIssues: filterAndSort(allIssues),
-      };
-    }
-    case "setIssueOrder": {
-      if (action.issueOrder === state.issueOrder) {
-        return state;
-      }
-      return {
-        ...state,
-        filteredIssues: sortBy(state.filteredIssues, orderIteratee),
-        issueOrder: action.issueOrder,
-      };
-    }
-  }
-
-  return state;
-}
-
-function diffReducer(state: State, diff: Diff): State {
-  if (diff.length === 0) {
-    return state;
-  }
-  const newAllIssuesMap = new Map(state.allIssuesMap);
-  let newViewIssueCount = state.viewIssueCount;
-  const newFilteredIssues = [...state.filteredIssues];
-  const orderIteratee = partial(getOrderValue, state.issueOrder);
-
-  function add(key: string, newValue: ReadonlyJSONValue) {
-    const newIssue = issueFromKeyAndValue(key, newValue);
-    newAllIssuesMap.set(key, newIssue);
-    if (state.filters.viewFilter(newIssue)) {
-      newViewIssueCount++;
-    }
-    if (state.filters.issuesFilter(newIssue)) {
-      newFilteredIssues.splice(
-        sortedIndexBy(newFilteredIssues, newIssue, orderIteratee),
-        0,
-        newIssue
-      );
-    }
-  }
-  function del(key: string, oldValue: ReadonlyJSONValue) {
-    const oldIssue = issueFromKeyAndValue(key, oldValue);
-    const index = sortedIndexBy(newFilteredIssues, oldIssue, orderIteratee);
-    newAllIssuesMap.delete(key);
-    if (state.filters.viewFilter(oldIssue)) {
-      newViewIssueCount--;
-    }
-    if (newFilteredIssues[index]?.id === oldIssue.id) {
-      newFilteredIssues.splice(index, 1);
-    }
-  }
-  for (const diffOp of diff) {
-    switch (diffOp.op) {
-      case "add": {
-        add(diffOp.key as string, diffOp.newValue);
-        break;
-      }
-      case "del": {
-        del(diffOp.key as string, diffOp.oldValue);
-        break;
-      }
-      case "change": {
-        del(diffOp.key as string, diffOp.oldValue);
-        add(diffOp.key as string, diffOp.newValue);
-        break;
-      }
-    }
-  }
-  return {
-    ...state,
-    allIssuesMap: newAllIssuesMap,
-    viewIssueCount: newViewIssueCount,
-    filteredIssues: newFilteredIssues,
-  };
-}
-
 type AppProps = {
   rep: Replicache<M>;
   undoManager: UndoManager;
@@ -350,13 +62,10 @@ const App = ({ rep, undoManager }: AppProps) => {
   const [detailIssueID, setDetailIssueID] = useQueryState("iss");
   const [menuVisible, setMenuVisible] = useState(false);
 
-  const [state, dispatch] = useReducer(timedReducer, {
-    allIssuesMap: new Map(),
-    viewIssueCount: 0,
-    filteredIssues: [],
-    filters: getFilters(view, priorityFilter, statusFilter),
-    issueOrder: getIssueOrder(view, orderBy),
-  });
+  const allIssuesMap = useAtomValue(allIssuesMapAtom);
+  const setFilters = useSetAtom(filtersAtom);
+  const setOrderBy = useSetAtom(issueOrderAtom);
+  const diffHandler = useSetAtom(diffHandlerAtom);
 
   const partialSync = useSubscribe<
     PartialSyncState | "NOT_RECEIVED_FROM_SERVER"
@@ -377,35 +86,29 @@ const App = ({ rep, undoManager }: AppProps) => {
   }, [rep, partialSync, partialSyncComplete]);
 
   useEffect(() => {
-    rep.experimentalWatch(
-      (diff) => {
-        dispatch({
-          type: "diff",
-          diff,
-        });
-      },
-      { prefix: ISSUE_KEY_PREFIX, initialValuesInFirstDiff: true }
-    );
+    rep.experimentalWatch(diffHandler, {
+      prefix: ISSUE_KEY_PREFIX,
+      initialValuesInFirstDiff: true,
+    });
   }, [rep]);
 
-  useEffect(() => {
-    dispatch({
-      type: "setFilters",
-      filters: getFilters(view, priorityFilter, statusFilter),
-    });
-  }, [view, priorityFilter, statusFilter]);
+  useEffect(() => setFilters(getFilters(view, priorityFilter, statusFilter)), [
+    view,
+    priorityFilter,
+    statusFilter,
+    setFilters,
+  ]);
 
-  useEffect(() => {
-    dispatch({
-      type: "setIssueOrder",
-      issueOrder: getIssueOrder(view, orderBy),
-    });
-  }, [view, orderBy]);
+  useEffect(() => setOrderBy(getIssueOrder(view, orderBy)), [
+    view,
+    orderBy,
+    setOrderBy,
+  ]);
 
   const handleCreateIssue = useCallback(
     async (issue: Omit<Issue, "kanbanOrder">, description: Description) => {
       const minKanbanOrderIssue = minBy(
-        [...state.allIssuesMap.values()],
+        [...allIssuesMap.values()],
         (issue) => issue.kanbanOrder
       );
       const minKanbanOrder = minKanbanOrderIssue
@@ -420,7 +123,7 @@ const App = ({ rep, undoManager }: AppProps) => {
         description,
       });
     },
-    [rep.mutate, state.allIssuesMap]
+    [rep.mutate, allIssuesMap]
   );
   const handleCreateComment = useCallback(
     async (comment: Comment) => {
@@ -495,7 +198,6 @@ const App = ({ rep, undoManager }: AppProps) => {
         view={view}
         detailIssueID={detailIssueID}
         isLoading={!partialSyncComplete}
-        state={state}
         rep={rep}
         onCloseMenu={handleCloseMenu}
         onToggleMenu={handleToggleMenu}
@@ -518,7 +220,6 @@ interface LayoutProps {
   view: string | null;
   detailIssueID: string | null;
   isLoading: boolean;
-  state: State;
   rep: Replicache<M>;
   onCloseMenu: () => void;
   onToggleMenu: () => void;
@@ -536,7 +237,6 @@ const RawLayout = ({
   view,
   detailIssueID,
   isLoading,
-  state,
   rep,
   onCloseMenu,
   onToggleMenu,
@@ -561,20 +261,12 @@ const RawLayout = ({
           >
             <TopFilter
               onToggleMenu={onToggleMenu}
-              title={getTitle(view)}
-              filteredIssuesCount={
-                state.filters.hasNonViewFilters
-                  ? state.filteredIssues.length
-                  : undefined
-              }
-              issuesCount={state.viewIssueCount}
               showSortOrderMenu={view !== "board"}
             />
           </div>
           <div className="relative flex flex-1 min-h-0">
             {detailIssueID && (
               <IssueDetail
-                issues={state.filteredIssues}
                 rep={rep}
                 onUpdateIssues={onUpdateIssues}
                 onAddComment={onCreateComment}
@@ -590,16 +282,13 @@ const RawLayout = ({
             >
               {view === "board" ? (
                 <IssueBoard
-                  issues={state.filteredIssues}
                   onUpdateIssues={onUpdateIssues}
                   onOpenDetail={onOpenDetail}
                 />
               ) : (
                 <IssueList
-                  issues={state.filteredIssues}
                   onUpdateIssues={onUpdateIssues}
                   onOpenDetail={onOpenDetail}
-                  view={view}
                 />
               )}
             </div>

--- a/frontend/issue-board.tsx
+++ b/frontend/issue-board.tsx
@@ -1,10 +1,12 @@
 import { generateNKeysBetween } from "fractional-indexing";
+import { useAtomValue } from "jotai";
 import { groupBy, indexOf } from "lodash";
 import React, { memo, useCallback } from "react";
 import { DragDropContext, DropResult } from "react-beautiful-dnd";
 
 import { Status, Issue, IssueUpdate, Priority } from "./issue";
 import IssueCol from "./issue-col";
+import { displayedIssuesAtom } from "./state";
 
 export type IssuesByStatusType = {
   [Status.BACKLOG]: Issue[];
@@ -71,12 +73,13 @@ export function getKanbanOrderIssueUpdates(
 }
 
 interface Props {
-  issues: Issue[];
+  // issues: Issue[];
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onOpenDetail: (issue: Issue) => void;
 }
 
-function IssueBoard({ issues, onUpdateIssues, onOpenDetail }: Props) {
+function IssueBoard({ onUpdateIssues, onOpenDetail }: Props) {
+  const issues = useAtomValue(displayedIssuesAtom);
   const issuesByType = getIssueByType(issues);
 
   const handleDragEnd = useCallback(

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -27,11 +27,13 @@ import { nanoid } from "nanoid";
 import { timeAgo } from "../util/date";
 import { useKeyPressed } from "./hooks/useKeyPressed";
 import { sortBy } from "lodash";
+import { useAtomValue } from "jotai";
+import { displayedIssuesAtom } from "./state";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onAddComment: (comment: Comment) => void;
-  issues: Issue[];
+  // issues: Issue[];
   isLoading: boolean;
   rep: Replicache<M>;
 }
@@ -70,9 +72,10 @@ export default function IssueDetail({
   rep,
   onUpdateIssues,
   onAddComment,
-  issues,
+  // issues,
   isLoading,
 }: Props) {
+  const issues = useAtomValue(displayedIssuesAtom);
   const [detailIssueID, setDetailIssueID] = useQueryState("iss", {
     history: "push",
   });

--- a/frontend/issue-list.tsx
+++ b/frontend/issue-list.tsx
@@ -10,12 +10,13 @@ import IssueRow from "./issue-row";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 import type { Issue, IssueUpdate, Priority, Status } from "./issue";
+import { displayedIssuesAtom } from "./state";
+import { useAtomValue } from "jotai";
+import { useQueryState } from "next-usequerystate";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onOpenDetail: (issue: Issue) => void;
-  issues: Issue[];
-  view: string | null;
 }
 
 type ListData = {
@@ -48,7 +49,9 @@ const RawRow = ({
 
 const Row = memo(RawRow);
 
-const IssueList = ({ onUpdateIssues, onOpenDetail, issues, view }: Props) => {
+const IssueList = ({ onUpdateIssues, onOpenDetail }: Props) => {
+  const [view] = useQueryState("view");
+  const issues = useAtomValue(displayedIssuesAtom);
   const fixedSizeListRef = useRef<FixedSizeList>(null);
   useEffect(() => {
     fixedSizeListRef.current?.scrollTo(0);

--- a/frontend/state.ts
+++ b/frontend/state.ts
@@ -1,0 +1,262 @@
+import { atom } from "jotai";
+import { isEqual, partial, sortBy, sortedIndexBy } from "lodash";
+import type { ExperimentalDiff, ReadonlyJSONValue } from "replicache";
+import {
+  Issue,
+  issueFromKeyAndValue,
+  Order,
+  Priority,
+  priorityEnumSchema,
+  priorityOrderValues,
+  reverseTimestampSortKey,
+  Status,
+  statusEnumSchema,
+  statusOrderValues,
+} from "./issue";
+
+export class Filters {
+  private readonly _viewStatuses: Set<Status> | undefined;
+  private readonly _issuesStatuses: Set<Status> | undefined;
+  private readonly _issuesPriorities: Set<Priority> | undefined;
+  readonly hasNonViewFilters: boolean;
+  constructor(
+    view: string | null,
+    priorityFilter: string | null,
+    statusFilter: string | null
+  ) {
+    this._viewStatuses = undefined;
+    switch (view?.toLowerCase()) {
+      case "active":
+        this._viewStatuses = new Set([Status.IN_PROGRESS, Status.TODO]);
+        break;
+      case "backlog":
+        this._viewStatuses = new Set([Status.BACKLOG]);
+        break;
+      default:
+        this._viewStatuses = undefined;
+    }
+
+    this._issuesStatuses = undefined;
+    this._issuesPriorities = undefined;
+    this.hasNonViewFilters = false;
+    if (statusFilter) {
+      this._issuesStatuses = new Set<Status>();
+      for (const s of statusFilter.split(",")) {
+        const parseResult = statusEnumSchema.safeParse(s);
+        if (
+          parseResult.success &&
+          (!this._viewStatuses || this._viewStatuses.has(parseResult.data))
+        ) {
+          this.hasNonViewFilters = true;
+          this._issuesStatuses.add(parseResult.data);
+        }
+      }
+    }
+    if (!this.hasNonViewFilters) {
+      this._issuesStatuses = this._viewStatuses;
+    }
+
+    if (priorityFilter) {
+      this._issuesPriorities = new Set<Priority>();
+      for (const p of priorityFilter.split(",")) {
+        const parseResult = priorityEnumSchema.safeParse(p);
+        if (parseResult.success) {
+          this.hasNonViewFilters = true;
+          this._issuesPriorities.add(parseResult.data);
+        }
+      }
+      if (this._issuesPriorities.size === 0) {
+        this._issuesPriorities = undefined;
+      }
+    }
+  }
+
+  viewFilter(issue: Issue): boolean {
+    return this._viewStatuses ? this._viewStatuses.has(issue.status) : true;
+  }
+
+  issuesFilter(issue: Issue): boolean {
+    if (this._issuesStatuses) {
+      if (!this._issuesStatuses.has(issue.status)) {
+        return false;
+      }
+    }
+    if (this._issuesPriorities) {
+      if (!this._issuesPriorities.has(issue.priority)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  equals(other: Filters): boolean {
+    return (
+      this === other ||
+      (isEqual(this._viewStatuses, other._viewStatuses) &&
+        isEqual(this._issuesStatuses, other._issuesStatuses) &&
+        isEqual(this._issuesPriorities, other._issuesPriorities) &&
+        isEqual(this.hasNonViewFilters, other.hasNonViewFilters))
+    );
+  }
+}
+
+export const allIssuesMapAtom = atom<Map<string, Issue>>(new Map());
+const rawDisplayedIssuesAtom = atom<Issue[]>([]);
+export const viewIssueCountAtom = atom(0);
+
+// read only atom used for display
+export const displayedIssuesAtom = atom((get) => get(rawDisplayedIssuesAtom));
+
+type ViewPreset = "all" | "active" | "backlog" | "board";
+const rawViewAtom = atom<ViewPreset>("all");
+export const viewAtom = atom<ViewPreset, ViewPreset>(
+  (get) => get(rawViewAtom),
+  (_, set, view) => {
+    set(rawViewAtom, view);
+    set(refreshDisplayIssuesAtom);
+  }
+);
+
+// filters
+const rawFiltersAtom = atom<Filters>(new Filters(null, null, null));
+export const filtersAtom = atom(
+  (get) => get(rawFiltersAtom),
+  (_, set, filters: Filters) => {
+    set(rawFiltersAtom, filters);
+    set(refreshDisplayIssuesAtom);
+  }
+);
+
+// order
+const rawIssueOrderAtom = atom<Order>(Order.MODIFIED);
+export const issueOrderAtom = atom(
+  (get) => get(rawIssueOrderAtom),
+  (get, set, order: Order) => {
+    if (order === get(rawIssueOrderAtom)) {
+      return;
+    }
+    set(rawIssueOrderAtom, order);
+    set(
+      rawDisplayedIssuesAtom,
+      sortBy(get(rawDisplayedIssuesAtom), partial(getOrderValue, order))
+    );
+  }
+);
+
+export const diffHandlerAtom = atom<unknown, ExperimentalDiff>(
+  null,
+  (get, set, diff) => {
+    if (diff.length === 0) {
+      return;
+    }
+    const start = Date.now();
+    const newAllIssuesMap = get(allIssuesMapAtom);
+    let newViewIssueCount = get(viewIssueCountAtom);
+    const newFilteredIssues = [...get(rawDisplayedIssuesAtom)];
+    const orderIteratee = partial(getOrderValue, get(rawIssueOrderAtom));
+    const filters = get(rawFiltersAtom);
+
+    function add(key: string, newValue: ReadonlyJSONValue) {
+      const newIssue = issueFromKeyAndValue(key, newValue);
+      newAllIssuesMap.set(key, newIssue);
+      if (filters.viewFilter(newIssue)) {
+        newViewIssueCount++;
+      }
+      if (filters.issuesFilter(newIssue)) {
+        newFilteredIssues.splice(
+          sortedIndexBy(newFilteredIssues, newIssue, orderIteratee),
+          0,
+          newIssue
+        );
+      }
+    }
+    function del(key: string, oldValue: ReadonlyJSONValue) {
+      const oldIssue = issueFromKeyAndValue(key, oldValue);
+      const index = sortedIndexBy(newFilteredIssues, oldIssue, orderIteratee);
+      newAllIssuesMap.delete(key);
+      if (filters.viewFilter(oldIssue)) {
+        newViewIssueCount--;
+      }
+      if (newFilteredIssues[index]?.id === oldIssue.id) {
+        newFilteredIssues.splice(index, 1);
+      }
+    }
+    for (const diffOp of diff) {
+      switch (diffOp.op) {
+        case "add": {
+          add(diffOp.key as string, diffOp.newValue);
+          break;
+        }
+        case "del": {
+          del(diffOp.key as string, diffOp.oldValue);
+          break;
+        }
+        case "change": {
+          del(diffOp.key as string, diffOp.oldValue);
+          add(diffOp.key as string, diffOp.newValue);
+          break;
+        }
+      }
+    }
+    set(viewIssueCountAtom, newViewIssueCount);
+    set(rawDisplayedIssuesAtom, newFilteredIssues);
+    console.log(`Diff Handler took ${Date.now() - start}ms`);
+  }
+);
+
+const refreshDisplayIssuesAtom = atom(null, (get, set) => {
+  const allIssues = [...get(allIssuesMapAtom).values()];
+  const orderIteratee = partial(getOrderValue, get(rawIssueOrderAtom));
+  const filters = get(rawFiltersAtom);
+  set(viewIssueCountAtom, countViewIssues(allIssues, filters));
+  set(rawDisplayedIssuesAtom, filterAndSort(allIssues, filters, orderIteratee));
+});
+
+function countViewIssues(issues: Issue[], filters: Filters): number {
+  let count = 0;
+  for (const issue of issues) {
+    if (filters.viewFilter(issue)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function filterAndSort(
+  issues: Issue[],
+  filters: Filters,
+  orderIteratee: (i: Issue) => string
+): Issue[] {
+  return sortBy(
+    issues.filter((issue) => filters.issuesFilter(issue)),
+    orderIteratee
+  );
+}
+
+export function getOrderValue(issueOrder: Order, issue: Issue): string {
+  let orderValue: string;
+  switch (issueOrder) {
+    case Order.CREATED:
+      orderValue = reverseTimestampSortKey(issue.created, issue.id);
+      break;
+    case Order.MODIFIED:
+      orderValue = reverseTimestampSortKey(issue.modified, issue.id);
+      break;
+    case Order.STATUS:
+      orderValue =
+        statusOrderValues[issue.status] +
+        "-" +
+        reverseTimestampSortKey(issue.modified, issue.id);
+      break;
+    case Order.PRIORITY:
+      orderValue =
+        priorityOrderValues[issue.priority] +
+        "-" +
+        reverseTimestampSortKey(issue.modified, issue.id);
+      break;
+    case Order.KANBAN:
+      orderValue = issue.kanbanOrder + "-" + issue.id;
+      break;
+  }
+  return orderValue;
+}

--- a/frontend/top-filter.tsx
+++ b/frontend/top-filter.tsx
@@ -1,16 +1,15 @@
+import { memo } from "react";
 import MenuIcon from "./assets/icons/menu.svg";
-import React, { memo } from "react";
 
-import SortOrderMenu from "./sort-order-menu";
+import { useAtomValue } from "jotai";
 import { queryTypes, useQueryState } from "next-usequerystate";
 import FilterMenu from "./filter-menu";
 import { Order, Priority, Status } from "./issue";
+import SortOrderMenu from "./sort-order-menu";
+import { displayedIssuesAtom, filtersAtom, viewIssueCountAtom } from "./state";
 
 interface Props {
-  title: string;
   onToggleMenu?: () => void;
-  filteredIssuesCount?: number;
-  issuesCount: number;
   showSortOrderMenu: boolean;
 }
 
@@ -18,6 +17,19 @@ interface FilterStatusProps {
   filter: Status[] | Priority[] | null;
   onDelete: () => void;
   label: string;
+}
+
+function getTitle(view: string | null) {
+  switch (view?.toLowerCase()) {
+    case "active":
+      return "Active issues";
+    case "backlog":
+      return "Backlog issues";
+    case "board":
+      return "Board";
+    default:
+      return "All issues";
+  }
 }
 
 const displayStrings: Record<Priority | Status, string> = {
@@ -54,13 +66,17 @@ const FilterStatus = ({ filter, onDelete, label }: FilterStatusProps) => {
   );
 };
 
-const TopFilter = ({
-  title,
-  onToggleMenu,
-  filteredIssuesCount,
-  issuesCount,
-  showSortOrderMenu,
-}: Props) => {
+const TopFilter = ({ onToggleMenu }: Props) => {
+  const [view] = useQueryState("view");
+  const title = getTitle(view);
+  const showSortOrderMenu = view !== "board";
+  const filters = useAtomValue(filtersAtom);
+  const issuesCount = useAtomValue(viewIssueCountAtom);
+  const displayedIssues = useAtomValue(displayedIssuesAtom);
+  const filteredIssuesCount = filters.hasNonViewFilters
+    ? displayedIssues.length
+    : undefined;
+
   const [orderBy, setOrderByParam] = useQueryState(
     "orderBy",
     queryTypes

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "classnames": "^2.3.1",
         "fractional-indexing": "^3.0.1",
         "gzip-loader": "^0.0.1",
+        "jotai": "^1.8.0",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.1",
         "next": "latest",
@@ -6491,6 +6492,55 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/jotai": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.8.0.tgz",
+      "integrity": "sha512-B77a5hIDGCxePYrYBpHP6YePGyNwivA+vXO6QME+8+t3V0y+OHwwnHu4Wy/LWEChE/G8vI+K7P2tlToT8Zmjng==",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "@babel/template": "*",
+        "@tanstack/query-core": "*",
+        "@urql/core": "*",
+        "immer": "*",
+        "optics-ts": "*",
+        "react": ">=16.8",
+        "valtio": "*",
+        "wonka": "*",
+        "xstate": "*"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@tanstack/query-core": {
+          "optional": true
+        },
+        "@urql/core": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "optics-ts": {
+          "optional": true
+        },
+        "valtio": {
+          "optional": true
+        },
+        "wonka": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14415,6 +14465,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jotai": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.8.0.tgz",
+      "integrity": "sha512-B77a5hIDGCxePYrYBpHP6YePGyNwivA+vXO6QME+8+t3V0y+OHwwnHu4Wy/LWEChE/G8vI+K7P2tlToT8Zmjng==",
+      "requires": {}
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "classnames": "^2.3.1",
     "fractional-indexing": "^3.0.1",
     "gzip-loader": "^0.0.1",
+    "jotai": "^1.8.0",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.1",
     "next": "latest",


### PR DESCRIPTION
# Jotai Usage Spike with `watch()`

## Background

(When you see [Jotai](https://jotai.org/) in this, you can replace it with "a reactive state management library". There are others: zustand, MobX, recoil, etc.)

Jotai is a state management library for React. A common way to use it is to combine pieces of state (atoms) in into "derived" atoms. A derived atom will fire/update when one of its dependencies is updated.  Atoms are used to render components, and update via hooks. One of the selling points of Jotai is to avoid unnecessary rendering, as you can import whatever state you need directly into your component, instead of drilling it down via props.

The proposed [`watch()` API](https://www.notion.so/replicache/watch-cf3110a59db446a59848ea40f48b799b) had options for filtering, sorting, and also there was also interest on discord in a mapping/joining option. After doing some research and implementing the API in some spikes, we learned that some clients were already using Jotai for "derived" data, and they suggested that it could be used instead of building this feature set.

The thinking was: if we could implement sorting, filtering, and joins using Jotai, using some reasonable patterns, we could recommend it to customers, and forego building it into Replicache or a utility library.

## Summary
For a high performance app with lots of data like Repliear, you will be writing code to do fast state updates. The basic declarative approach used in Jotai examples don't easily lend themselves to fine-grained optimization. To achieve the same performance that exists currently in Repliear, a similar approach needs to happen within Jotai. 
Jotai makes things cleaner in some ways, but more obtuse in other ways.

- Good: You can `import` state directly in components instead of drilling it down, preventing some extra renders. In Repliear however, whenever there is a change in an Issue, the entire displayed list often needs to get resorted.
- Good: You can remove the use of `useSubscribe()` in components for reactivity, and essentially have just a single method which gets Replicache updates, and rely on Jotai hooks to trigger re-renders.
- Bad: If you want to have fine-grained control over modifying derived state, like we do in Repliear, you have to jump through some hoops with Jotai. You often have split a piece of state into two items: the actual JS data, and one or more "action" atoms which modify the state in specific ways.

## Conclusion

It seems like there is enough out there that we don't need to build in filter/sort/map into `watch()`. For smaller datasets/spaces, Jotai would be compelling, and with more complex apps like Repliear, either rolling your own filter/sort or doing it within the conetxt of a state manager would be about the same amount of code. In either case, having a reactive state manager is convenient.
