### PR TITLE
fix: In Replicache 13, cookies must increase if the data has changed.

### DIFF
--- a/pages/api/replicache-pull.ts
+++ b/pages/api/replicache-pull.ts
@@ -7,6 +7,7 @@ import {
   getLastMutationIDsSince,
   getNonIssueEntriesInSyncOrder,
   getVersion,
+  incrementPullID,
 } from "../../backend/data";
 import { z } from "zod";
 import {
@@ -74,6 +75,9 @@ const pull = async (req: NextApiRequest, res: NextApiResponse) => {
     if (version === undefined) {
       return undefined;
     }
+
+    const nextPullID = await incrementPullID(executor, clientGroupID);
+
     if (!requestCookie) {
       const lastMutationIDPromise = await getLastMutationIDsSince(
         executor,
@@ -84,7 +88,7 @@ const pull = async (req: NextApiRequest, res: NextApiResponse) => {
       const responseCookie: Cookie = {
         version,
         partialSync: "ISSUES_SYNCED",
-        order: version,
+        order: nextPullID,
       };
       const partialSyncState: PartialSyncState = "ISSUES_SYNCED";
       entries.push([PARTIAL_SYNC_STATE_KEY, JSON.stringify(partialSyncState)]);
@@ -135,7 +139,7 @@ const pull = async (req: NextApiRequest, res: NextApiResponse) => {
       const responseCookie: Cookie = {
         version,
         partialSync: responsePartialSyncState,
-        order: version,
+        order: nextPullID,
       };
       return Promise.all([entries, lastMutationIDPromise, responseCookie]);
     }


### PR DESCRIPTION
If the cookie stays the same, Replicache ignores the pull response.

This was causing Repliear to resync most of the data on every load, because only the first pull response was ever saved, because unless any edits were made the subsequent pull responses didn't have their cookie change and so were ignored.

This gave me an idea though that is broader than Repliear: can just introduce the concept of 'pull ID', yet another counter :).

This makes it a little more concrete than 'cvr version' and it would also apply to most of the other strategies.